### PR TITLE
Add developer's ~/.gitconfig folder as bound volume

### DIFF
--- a/activate-workspace.sh
+++ b/activate-workspace.sh
@@ -97,6 +97,7 @@ docker run -it --rm  \
     -v ${MOUNT_DIR}:/workspaces/${MOUNT_NAME} \
     -v `realpath ~/.cache`:/tmp/.cache \
     -v `realpath ~/.ssh`:/tmp/.ssh \
+    -v `realpath ~/.gitconfig`:/etc/gitconfig \
     -e DOCKER_HOST_USER_ID=`id -u` \
     -e DOCKER_HOST_GROUP_ID=`id -g` \
     -e DISPLAY \


### PR DESCRIPTION
When activating a Docker workspace, it would be useful if the developer's host machine git configuration (username, email, etc.) was available to the guest environment. This one-line fix does exactly that by binding the relevant volumes during the `docker run` command.