### PR TITLE
Bind the ~/.config folder in the remote container

### DIFF
--- a/activate-workspace.sh
+++ b/activate-workspace.sh
@@ -97,6 +97,7 @@ docker run -it --rm  \
     -v ${MOUNT_DIR}:/workspaces/${MOUNT_NAME} \
     -v `realpath ~/.cache`:/tmp/.cache \
     -v `realpath ~/.ssh`:/tmp/.ssh \
+    -v `realpath ~/.config`:/tmp/.config \
     -v `realpath ~/.gitconfig`:/etc/gitconfig \
     -e DOCKER_HOST_USER_ID=`id -u` \
     -e DOCKER_HOST_GROUP_ID=`id -g` \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -19,6 +19,9 @@ set -- gosu admin "$@"
 # Link the host user .ssh directory for credentials.
 su -l admin -c "ln -s /tmp/.ssh ~/.ssh"
 
+# Link the host user .config directory for configurations.
+su -l admin -c "ln -s /tmp/.config ~/.config"
+
 # Impersonate admin and invoke workspace-entrypoint.sh
 if [[ -f "/usr/local/bin/workspace-entrypoint.sh" ]]; then
     su -l admin "/usr/local/bin/workspace-entrypoint.sh"


### PR DESCRIPTION
The primary motivation of this change is to allow the remote container to make changes to the `~/.config/Code/` folder for VSCode configuration settings. If there are concerns that this is linking too much of the host machine and Docker container, we can specifically link just the `~/.config/Code` folders.